### PR TITLE
Fix issue where FNumber would always return 1

### DIFF
--- a/SonyAlphaUSB/SonyCamera.cs
+++ b/SonyAlphaUSB/SonyCamera.cs
@@ -40,7 +40,7 @@ namespace SonyAlphaUSB
             }
         }
 
-        public int FNumber
+        public double FNumber
         {
             get { return GetFNumber(); }
         }
@@ -834,10 +834,10 @@ namespace SonyAlphaUSB
             DoMainSettingI16(SettingIds.RecordVideo, 1);
         }
 
-        public int GetFNumber()
+        public double GetFNumber()
         {
-            CameraSetting setting = GetSetting(SettingIds.LiveViewState);
-            return setting != null ? setting.Value : 0;
+            CameraSetting setting = GetSetting(SettingIds.FNumber);
+            return setting != null ? (double)setting.Value/100 : 0;
         }
 
         public void ModifyFNumber(short steps)


### PR DESCRIPTION
GetFNumber function was incorrectly getting it's value from SettingIds.LiveVeiwState when it should've been using SettingIds.FNumber. 
This fixes issue #2 